### PR TITLE
chore: use ruff format instead of black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ testpaths = ["tests"]
 src = ["robyn_rate_limits", "tests"]
 target-version = "py38"
 line-length = 99
+
+[tool.ruff.lint]
 select = [
     "A",    #  builtins
     "ARG",  #  unsued arguments
@@ -55,11 +57,14 @@ select = [
     "UP",   #  pyupgrade
     "W",    #  warnings
 ]
+ignore = [
+    "COM812",  # avoid conflicts
+]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 8
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 force-single-line = true
 
 [build-system]

--- a/robyn_rate_limits/protocols.py
+++ b/robyn_rate_limits/protocols.py
@@ -2,5 +2,8 @@ from typing import Protocol
 
 
 class LimitStore(Protocol):
-    def get_calls_count(self, limit_key: str, current_timestamp: int) -> int:
-        ...  # pragma: no cover
+    def get_calls_count(
+        self,
+        limit_key: str,
+        current_timestamp: int,
+    ) -> int: ...  # pragma: no cover

--- a/tox.ini
+++ b/tox.ini
@@ -19,11 +19,10 @@ commands =
 
 [testenv:lint]
 deps =
-    black
     ruff
     mypy
 commands =
-    black --check robyn_rate_limits/
+    ruff format --check robyn_rate_limits/
     ruff check robyn_rate_limits/
     mypy --ignore-missing-imports --install-types --non-interactive robyn_rate_limits/
 


### PR DESCRIPTION
**Description**

This PR removes black from the process and use ruff format alongside ruff lint

<!--
Thank you for your contribution!

Contributing conventions:

1. Please make sure you followed the [contributing guidelines](https://github.com/IdoKendo/robyn_rate_limits/blob/main/CONTRIBUTING.md) before submitting your PR.
2. Include descriptive PR titles.
3. Build and test your changes before submitting a PR.

-->
